### PR TITLE
Removing the inherent dependency on a locally installed Seeq

### DIFF
--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -21,13 +21,15 @@ namespace Seeq.Link.Debugging.Agent {
 
             // Provide a name for the agent that differentiates it from the "normal" .NET Agent
             config.Name = ".NET Connector SDK Debugging Agent";
+            config.SeeqUrl = new Uri("https://yourserver.seeq.host");
 
             // Specify the data folder; change this if you've configured Seeq to use a different location!
             config.DataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Seeq", "data");
-
+            config.IsRemoteAgent = true;
             // Set the connectorSearchPaths to only find connectors within the connector-sdk folder
 
             string executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
+            config.DataFolder = Path.Combine(Path.GetDirectoryName(executingAssemblyLocation), "data");
 
             string connectorSdkRoot = Path.GetFullPath(Path.Combine(executingAssemblyLocation, "..", "..", "..", "..", ".."));
             string configuration = "Release";

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -119,6 +119,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="data\keys\agent.key">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.key
+++ b/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.key
@@ -1,0 +1,2 @@
+﻿agent_api_key
+<your_agent_api_key>


### PR DESCRIPTION
This PR removes the assumption that there is a locally installed Seeq / Remote Agent