### PR TITLE
CRAB-41403: Use compression library in csharp connector-sdk

### DIFF
--- a/MyCompany.Seeq.Link.Connector.MyConnector.Test/MyCompany.Seeq.Link.Connector.MyConnector.Test.csproj
+++ b/MyCompany.Seeq.Link.Connector.MyConnector.Test/MyCompany.Seeq.Link.Connector.MyConnector.Test.csproj
@@ -77,11 +77,11 @@
     <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.SDK, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Link.SDK.64.0.3\lib\net48\Seeq.Link.SDK.dll</HintPath>
+    <Reference Include="Seeq.Link.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Link.SDK.65.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.SDK, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.SDK.64.0.3\lib\net45\Seeq.SDK.dll</HintPath>
+    <Reference Include="Seeq.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.SDK.65.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MyCompany.Seeq.Link.Connector.MyConnector.Test/packages.config
+++ b/MyCompany.Seeq.Link.Connector.MyConnector.Test/packages.config
@@ -13,8 +13,8 @@
   <package id="NUnit" version="3.14.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
-  <package id="Seeq.Link.SDK" version="64.0.3" targetFramework="net48" />
-  <package id="Seeq.SDK" version="64.0.3" targetFramework="net48" />
+  <package id="Seeq.Link.SDK" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.SDK" version="65.0.0-dev" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/MyCompany.Seeq.Link.Connector.MyConnector/MyCompany.Seeq.Link.Connector.MyConnector.csproj
+++ b/MyCompany.Seeq.Link.Connector.MyConnector/MyCompany.Seeq.Link.Connector.MyConnector.csproj
@@ -57,11 +57,11 @@
     <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.SDK, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Link.SDK.64.0.3\lib\net48\Seeq.Link.SDK.dll</HintPath>
+    <Reference Include="Seeq.Link.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Link.SDK.65.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.SDK, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.SDK.64.0.3\lib\net45\Seeq.SDK.dll</HintPath>
+    <Reference Include="Seeq.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.SDK.65.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/MyCompany.Seeq.Link.Connector.MyConnector/packages.config
+++ b/MyCompany.Seeq.Link.Connector.MyConnector/packages.config
@@ -8,6 +8,6 @@
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
   <package id="NodaTime" version="2.2.4" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
-  <package id="Seeq.Link.SDK" version="64.0.3" targetFramework="net48" />
-  <package id="Seeq.SDK" version="64.0.3" targetFramework="net48" />
+  <package id="Seeq.Link.SDK" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.SDK" version="65.0.0-dev" targetFramework="net48" />
 </packages>

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -60,6 +60,10 @@
     <Reference Include="Google.ProtocolBuffers.Serialization, Version=2.4.1.521, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
     </Reference>
+    <Reference Include="Google.Protobuf">
+      <Private>True</Private>
+      <HintPath>..\packages\Google.Protobuf.3.24.3\lib\net45\Google.Protobuf.dll</HintPath>
+    </Reference>
     <Reference Include="Ionic.Zip, Version=1.9.7.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.1.9.7\lib\net20\Ionic.Zip.dll</HintPath>
     </Reference>
@@ -90,17 +94,32 @@
     <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.Agent, Version=64.0.3.0, Culture=neutral, processorArchitecture=Amd64">
-      <HintPath>..\packages\Seeq.Link.Agent.64.0.3\lib\net48\Seeq.Link.Agent.exe</HintPath>
+    <Reference Include="Seeq.Link.Agent, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=Amd64">
+      <HintPath>..\packages\Seeq.Link.Agent.65.0.0-dev\lib\net48\Seeq.Link.Agent.exe</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.SDK, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Link.SDK.64.0.3\lib\net48\Seeq.Link.SDK.dll</HintPath>
+    <Reference Include="Seeq.Link.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Link.SDK.65.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.SDK, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.SDK.64.0.3\lib\net45\Seeq.SDK.dll</HintPath>
+    <Reference Include="Seeq.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.SDK.65.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Utilities, Version=64.0.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Utilities.64.0.3\lib\net48\Seeq.Utilities.dll</HintPath>
+    <Reference Include="Seeq.Utilities, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Utilities.65.0.0-dev\lib\net48\Seeq.Utilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Seeq.Compression, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Compression.65.0.0-dev\lib\net48\Seeq.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="Seeq.Serialization, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Serialization.65.0.0-dev\lib\net48\Seeq.Serialization.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+        <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="ZstdSharp.Port">
+      <HintPath>..\packages\ZstdSharp.Port.0.7.2\lib\net461\ZstdSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Seeq.Link.SDK.Debugging.Agent/packages.config
+++ b/Seeq.Link.SDK.Debugging.Agent/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="DotNetZip" version="1.9.7" targetFramework="net48" />
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net48" />
+  <package id="Google.Protobuf" version="3.24.3" targetFramework="net45"/>
   <package id="JsonSubTypes" version="1.2.0" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Minimatch" version="1.1.0.0" targetFramework="net48" />
@@ -11,10 +12,15 @@
   <package id="NodaTime" version="2.2.4" targetFramework="net48" />
   <package id="OsInfo" version="1.2.0" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
-  <package id="Seeq.Link.Agent" version="64.0.3" targetFramework="net48" />
-  <package id="Seeq.Link.SDK" version="64.0.3" targetFramework="net48" />
-  <package id="Seeq.SDK" version="64.0.3" targetFramework="net48" />
-  <package id="Seeq.Utilities" version="64.0.3" targetFramework="net48" />
+  <package id="Seeq.Link.Agent" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Link.SDK" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.SDK" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Utilities" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Compression" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Serialization" version="65.0.0-dev" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
   <package id="WebSocket4Net" version="0.14.1" targetFramework="net48" />
   <package id="ContentFilesExample" version="1.0.2" targetFramework="net48" />
+  <package id="ZstdSharp.Port" version="0.7.2" targetFramework="net461"/>
 </packages>


### PR DESCRIPTION
Now, that [compression library was added in csharp](https://github.com/seeq12/crab/pull/6517) we need to also change seeq-connector-sdk-csharp to use the compression.


The tests I did:
I connected to develop, I indexed the example database, I tried reindex, trended signals and conditions and made sure no error is reported in the logs and trending worked ✅ 

Primary reviewer: @andre-rigon 