### PR TITLE
CRAB-42410: Include new Common.Message library

### DIFF
--- a/MyCompany.Seeq.Link.Connector.MyConnector.Test/MyCompany.Seeq.Link.Connector.MyConnector.Test.csproj
+++ b/MyCompany.Seeq.Link.Connector.MyConnector.Test/MyCompany.Seeq.Link.Connector.MyConnector.Test.csproj
@@ -77,11 +77,11 @@
     <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Link.SDK.65.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
+    <Reference Include="Seeq.Link.SDK, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Link.SDK.66.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.SDK.65.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
+    <Reference Include="Seeq.SDK, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.SDK.66.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MyCompany.Seeq.Link.Connector.MyConnector.Test/packages.config
+++ b/MyCompany.Seeq.Link.Connector.MyConnector.Test/packages.config
@@ -13,8 +13,8 @@
   <package id="NUnit" version="3.14.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
-  <package id="Seeq.Link.SDK" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.SDK" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Link.SDK" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.SDK" version="66.0.0-dev" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/MyCompany.Seeq.Link.Connector.MyConnector/MyCompany.Seeq.Link.Connector.MyConnector.csproj
+++ b/MyCompany.Seeq.Link.Connector.MyConnector/MyCompany.Seeq.Link.Connector.MyConnector.csproj
@@ -57,11 +57,11 @@
     <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Link.SDK.65.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
+    <Reference Include="Seeq.Link.SDK, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Link.SDK.66.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.SDK.65.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
+    <Reference Include="Seeq.SDK, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.SDK.66.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/MyCompany.Seeq.Link.Connector.MyConnector/packages.config
+++ b/MyCompany.Seeq.Link.Connector.MyConnector/packages.config
@@ -8,6 +8,6 @@
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
   <package id="NodaTime" version="2.2.4" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
-  <package id="Seeq.Link.SDK" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.SDK" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Link.SDK" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.SDK" version="66.0.0-dev" targetFramework="net48" />
 </packages>

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -94,23 +94,26 @@
     <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.Agent, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=Amd64">
-      <HintPath>..\packages\Seeq.Link.Agent.65.0.0-dev\lib\net48\Seeq.Link.Agent.exe</HintPath>
+    <Reference Include="Seeq.Link.Agent, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=Amd64">
+      <HintPath>..\packages\Seeq.Link.Agent.66.0.0-dev\lib\net48\Seeq.Link.Agent.exe</HintPath>
     </Reference>
-    <Reference Include="Seeq.Link.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Link.SDK.65.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
+    <Reference Include="Seeq.Link.SDK, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Link.SDK.66.0.0-dev\lib\net48\Seeq.Link.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.SDK, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.SDK.65.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
+    <Reference Include="Seeq.SDK, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.SDK.66.0.0-dev\lib\net45\Seeq.SDK.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Utilities, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Utilities.65.0.0-dev\lib\net48\Seeq.Utilities.dll</HintPath>
+    <Reference Include="Seeq.Utilities, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Utilities.66.0.0-dev\lib\net48\Seeq.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Compression, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Compression.65.0.0-dev\lib\net48\Seeq.Compression.dll</HintPath>
+    <Reference Include="Seeq.Compression, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Compression.66.0.0-dev\lib\net48\Seeq.Compression.dll</HintPath>
     </Reference>
-    <Reference Include="Seeq.Serialization, Version=65.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Seeq.Serialization.65.0.0-dev\lib\net48\Seeq.Serialization.dll</HintPath>
+    <Reference Include="Seeq.Message, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Message.66.0.0-dev\lib\net48\Seeq.Message.dll</HintPath>
+    </Reference>
+    <Reference Include="Seeq.Serialization, Version=66.0.0-dev.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Seeq.Serialization.66.0.0-dev\lib\net48\Seeq.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
         <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>

--- a/Seeq.Link.SDK.Debugging.Agent/packages.config
+++ b/Seeq.Link.SDK.Debugging.Agent/packages.config
@@ -12,12 +12,13 @@
   <package id="NodaTime" version="2.2.4" targetFramework="net48" />
   <package id="OsInfo" version="1.2.0" targetFramework="net48" />
   <package id="RestSharp" version="106.12.0" targetFramework="net48" />
-  <package id="Seeq.Link.Agent" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.Link.SDK" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.SDK" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.Utilities" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.Compression" version="65.0.0-dev" targetFramework="net48" />
-  <package id="Seeq.Serialization" version="65.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Link.Agent" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Link.SDK" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.SDK" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Utilities" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Compression" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Message" version="66.0.0-dev" targetFramework="net48" />
+  <package id="Seeq.Serialization" version="66.0.0-dev" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
   <package id="WebSocket4Net" version="0.14.1" targetFramework="net48" />


### PR DESCRIPTION
Include the new Common.Message library in the SDK.

Primary reviewer: @mar1u50 (volunteer!)

Exploratory testing notes:
- @mar1u50 uploaded the packages with version `66.0.0-dev` to nuget (thank you!)
- Followed the steps in the readme to build, test and deploy the example connector ✅ 
- Was able to index and trend with the example connection✅ 