### PR TITLE
CRAB-44303: use agent provisioned one-time passwords

### DIFF
--- a/MyCompany.Seeq.Link.Connector.MyConnector.Test/MyCompany.Seeq.Link.Connector.MyConnector.Test.csproj
+++ b/MyCompany.Seeq.Link.Connector.MyConnector.Test/MyCompany.Seeq.Link.Connector.MyConnector.Test.csproj
@@ -112,7 +112,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.20.71</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
     <PackageReference Include="NFluent">
       <Version>3.0.4</Version>

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Take the following steps to confirm a properly configured development environmen
 1. Confirm that no compile errors occurred.
 1. Open the `EntryPoint.cs` file in the `Seeq.Link.SDK.Debugging.Agent` project.
 1. Modify the URL on the line `const string seeqHostUrl = "https://yourserver.seeq.host"` to match your Seeq server
-1. Retrieve the agent_api_key from your Seeq Server by logging in as a Seeq Administrator and navigating to the API
-   Documentation page. Expand the System group and expand GET /system/agentKey. Click Execute
-1. Modify the `agent_api_key` in `resources\data\keys\agent.key` by replacing the `<your_agent_api_key>`
-   with the key that is located in the top response from the previous step. Note: it should only include the value. For
-   example if the return was `{"agentKey": "superSecret123"}` then the key is `superSecret123`
+1. Pre-provision this agent on your Seeq server by logging in as a Seeq Administrator and navigating to the Agents tab 
+   on the Administration page. Click the "Add Agent" button and fill the presented fields. Provide the machine name and 
+   ".NET Connector SDK Debugging Agent" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
+   Copy the displayed one-time password.
+1. Modify the `agentOneTimePassword` constant in the `EntryPoint.cs` file by replacing the `AGENT_ONE_TIME_PASSWORD_PLACEHOLDER`
+   with the one-time password obtained from the previous step.
 1. Set a breakpoint (*Debug* > *Toggle Breakpoint*) on the first line of the `Main()` function.
 1. Select *Debug* > *Start Debugging* to launch the debugger.
 1. You should hit the breakpoint you set. **This verifies that VS built your project correctly and can launch it in its

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and facilitate access to data in Seeq.
 Seeq connectors can be written in Java or C# but this repository is intended to be used for developing C# Connectors. 
 C# development requires Windows operating system.
 
-It is recommended that you initially test with a "test" version of your Seeq Remote Agent. This will seperate your 
+It is recommended that you initially test with a "test" version of your Seeq Remote Agent. This will separate your 
 production connections from your test connections, allowing you to restart the remote agent without impacting users. 
 This repository contains an embedded remote agent that allows your development environment to interactively debug 
 your connector. 
@@ -59,8 +59,7 @@ Take the following steps to confirm a properly configured development environmen
    on the Administration page. Click the "Add Agent" button and fill the presented fields. Provide the machine name and 
    ".NET Connector SDK Debugging Agent" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
    Copy the displayed one-time password.
-1. Modify the `agentOneTimePassword` constant in the `EntryPoint.cs` file by replacing the `AGENT_ONE_TIME_PASSWORD_PLACEHOLDER`
-   with the one-time password obtained from the previous step.
+1. Replace `<your_agent_one_time_password>` in the `agent.otp` file in the /data/keys/ directory with the one-time password obtained from the previous step.
 1. Set a breakpoint (*Debug* > *Toggle Breakpoint*) on the first line of the `Main()` function.
 1. Select *Debug* > *Start Debugging* to launch the debugger.
 1. You should hit the breakpoint you set. **This verifies that VS built your project correctly and can launch it in its

--- a/Seeq.Link.SDK.Debugging.Agent/AgentKeyHelper.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/AgentKeyHelper.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+
+namespace Seeq.Link.Debugging.Agent {
+
+    internal static class AgentKeyHelper {
+        private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_agent_one_time_password>";
+        private static string OtpFilePath = Path.Combine("data", "keys", "agent.otp");
+
+        public static bool IsAgentOneTimePasswordSet() {
+            var fileContent = ReadAgentOneTimePassword();
+            return fileContent != AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
+        }
+
+        public static string ReadAgentOneTimePassword() {
+            if (!File.Exists(OtpFilePath)) {
+                return null;
+            }
+
+            return File.ReadAllText(OtpFilePath).Trim();
+        }
+
+        public static void ResetAgentOneTimePasswordFile() {
+            File.WriteAllText(OtpFilePath, AGENT_ONE_TIME_PASSWORD_PLACEHOLDER);
+        }
+    }
+}

--- a/Seeq.Link.SDK.Debugging.Agent/AgentKeyHelper.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/AgentKeyHelper.cs
@@ -1,4 +1,7 @@
 ﻿using System.IO;
+using Seeq.Link.SDK.Services;
+using Seeq.Link.SDK.Utilities;
+using Seeq.Utilities;
 
 namespace Seeq.Link.Debugging.Agent {
 
@@ -6,12 +9,29 @@ namespace Seeq.Link.Debugging.Agent {
         private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_agent_one_time_password>";
         private static string OtpFilePath = Path.Combine("data", "keys", "agent.otp");
 
-        public static bool IsAgentOneTimePasswordSet() {
-            var fileContent = ReadAgentOneTimePassword();
+        public static void SetupAgentOtp(string seeqDataFolder, string agentName) {
+            if (isAgentOneTimePasswordSet()) {
+                var agentHelper = new AgentHelper(agentName);
+                var secretsPath = Path.Combine(seeqDataFolder, SeeqNames.Agents.AgentKeysFolderName, "agent.keys");
+                var secretsManager = new FileBasedSecretsManager(secretsPath);
+
+                // set the agent's pre-provisioned one-time password
+                var agentOneTimePassword = readAgentOneTimePassword();
+                var preProvisionedOneTimePasswordSecretName =
+                    $"{agentHelper.ProvisionedAgentUsername}|PRE_PROVISIONED_ONE_TIME_PASSWORD";
+                secretsManager.PutSecret(preProvisionedOneTimePasswordSecretName, agentOneTimePassword);
+
+                // clear the OTP
+                resetAgentOneTimePasswordFile();
+            }
+        }
+
+        private static bool isAgentOneTimePasswordSet() {
+            var fileContent = readAgentOneTimePassword();
             return fileContent != AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
         }
 
-        public static string ReadAgentOneTimePassword() {
+        private static string readAgentOneTimePassword() {
             if (!File.Exists(OtpFilePath)) {
                 return null;
             }
@@ -19,7 +39,7 @@ namespace Seeq.Link.Debugging.Agent {
             return File.ReadAllText(OtpFilePath).Trim();
         }
 
-        public static void ResetAgentOneTimePasswordFile() {
+        private static void resetAgentOneTimePasswordFile() {
             File.WriteAllText(OtpFilePath, AGENT_ONE_TIME_PASSWORD_PLACEHOLDER);
         }
     }

--- a/Seeq.Link.SDK.Debugging.Agent/AgentOtpHelper.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/AgentOtpHelper.cs
@@ -5,7 +5,7 @@ using Seeq.Utilities;
 
 namespace Seeq.Link.Debugging.Agent {
 
-    internal static class AgentKeyHelper {
+    internal static class AgentOtpHelper {
         private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_agent_one_time_password>";
         private static string OtpFilePath = Path.Combine("data", "keys", "agent.otp");
 

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -21,18 +21,19 @@ namespace Seeq.Link.Debugging.Agent {
 
         public static void Main(string[] args) {
             XmlConfigurator.Configure();
-            
+
             const string agentName = ".NET Connector SDK Debugging Agent";
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             var seeqDataFolder = Path.Combine(Path.GetDirectoryName(executingAssemblyLocation), "data");
 
             var agentKeyPath = Path.Combine(seeqDataFolder, "keys", "agent.key");
             var agentKeyReader = new AgentKeyReader(agentKeyPath);
+            agentKeyReader.Initialize();
 
             // if this agent has been configured with an agent key, then the agent will handle provisioning and no additional
             // provisioning is required. Otherwise, set the pre-provisioned one-time password and allow the agent finish up
             // provisioning.
-            if (string.IsNullOrWhiteSpace(agentKeyReader.AgentKeyCredential.AgentKeyPassword) 
+            if (string.IsNullOrWhiteSpace(agentKeyReader.AgentKeyCredential?.AgentKeyPassword)
                 || agentKeyReader.AgentKeyCredential.AgentKeyPassword == AGENT_API_KEY_PLACEHOLDER) {
                 const string agentOneTimePassword = AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
 
@@ -47,7 +48,7 @@ namespace Seeq.Link.Debugging.Agent {
                     secretsManager.PutSecret(preProvisionedOneTimePasswordSecretName, agentOneTimePassword);
                 }
             }
-            
+
             Program.Configuration config = Program.GetDefaultConfiguration();
 
             const string seeqHostUrl = "https://yourserver.seeq.host";

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using log4net.Config;
 using Seeq.Link.Agent;
 using Seeq.Link.SDK.Services;
 using Seeq.Link.SDK.Utilities;
@@ -19,7 +20,7 @@ namespace Seeq.Link.Debugging.Agent {
         private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_one_time_password>";
 
         public static void Main(string[] args) {
-            log4net.Config.XmlConfigurator.Configure();
+            XmlConfigurator.Configure();
             
             const string agentName = ".NET Connector SDK Debugging Agent";
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
@@ -47,7 +48,7 @@ namespace Seeq.Link.Debugging.Agent {
                 }
             }
             
-            Seeq.Link.Agent.Program.Configuration config = Seeq.Link.Agent.Program.GetDefaultConfiguration();
+            Program.Configuration config = Program.GetDefaultConfiguration();
 
             const string seeqHostUrl = "https://yourserver.seeq.host";
             config.SeeqUrl = new Uri(seeqHostUrl);
@@ -73,7 +74,7 @@ namespace Seeq.Link.Debugging.Agent {
 
             config.ConnectorSearchPaths = searchPath + ";" + platformSpecificSearchPath;
 
-            new Seeq.Link.Agent.Program().Run(new Seeq.Link.Agent.ClassFactory(), new Seeq.Link.SDK.ClassFactory(), config);
+            new Program().Run(new ClassFactory(), new SDK.ClassFactory(), config);
         }
     }
 }

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -25,7 +25,8 @@ namespace Seeq.Link.Debugging.Agent {
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             var seeqDataFolder = Path.Combine(Path.GetDirectoryName(executingAssemblyLocation), "data");
 
-            // change this value to the one-time password generated from the Agents tab of your Seeq server's Administration page
+            // change this value to the one-time password generated from the Agents tab of your Seeq server's Administration
+            // page providing the machine name and your connector's name
             const string agentOneTimePassword = AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
 
             if (agentOneTimePassword != AGENT_ONE_TIME_PASSWORD_PLACEHOLDER) {

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -15,6 +15,8 @@ namespace Seeq.Link.Debugging.Agent {
     /// to connect to the server and load the connector that is under development.
     /// </summary>
     public class EntryPoint {
+        private const string AGENT_API_KEY_PLACEHOLDER = "<your_agent_api_key>";
+        private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_one_time_password>";
 
         public static void Main(string[] args) {
             log4net.Config.XmlConfigurator.Configure();
@@ -29,17 +31,20 @@ namespace Seeq.Link.Debugging.Agent {
             // if this agent has been configured with an agent key, then the agent will handle provisioning and no additional
             // provisioning is required. Otherwise, set the pre-provisioned one-time password and allow the agent finish up
             // provisioning.
-            if (string.IsNullOrWhiteSpace(agentKeyReader.AgentKeyCredential.AgentKeyPassword) || agentKeyReader.AgentKeyCredential.AgentKeyPassword == "<your_agent_api_key>")
-            {
-                var agentHelper = new AgentHelper(agentName);
-                var secretsPath = Path.Combine(seeqDataFolder, SeeqNames.Agents.AgentKeysFolderName, "agent.keys");
-                var secretsManager = new FileBasedSecretsManager(secretsPath);
-            
-                // set the agent's pre-provisioned one-time password
-                const string agentOneTimePassword = "<your_one_time_password>";
-                var preProvisionedOneTimePasswordSecretName =
-                    $"{agentHelper.ProvisionedAgentUsername}|PRE_PROVISIONED_ONE_TIME_PASSWORD";
-                secretsManager.PutSecret(preProvisionedOneTimePasswordSecretName, agentOneTimePassword);
+            if (string.IsNullOrWhiteSpace(agentKeyReader.AgentKeyCredential.AgentKeyPassword) 
+                || agentKeyReader.AgentKeyCredential.AgentKeyPassword == AGENT_API_KEY_PLACEHOLDER) {
+                const string agentOneTimePassword = AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
+
+                if (agentOneTimePassword != AGENT_ONE_TIME_PASSWORD_PLACEHOLDER) {
+                    var agentHelper = new AgentHelper(agentName);
+                    var secretsPath = Path.Combine(seeqDataFolder, SeeqNames.Agents.AgentKeysFolderName, "agent.keys");
+                    var secretsManager = new FileBasedSecretsManager(secretsPath);
+
+                    // set the agent's pre-provisioned one-time password
+                    var preProvisionedOneTimePasswordSecretName =
+                        $"{agentHelper.ProvisionedAgentUsername}|PRE_PROVISIONED_ONE_TIME_PASSWORD";
+                    secretsManager.PutSecret(preProvisionedOneTimePasswordSecretName, agentOneTimePassword);
+                }
             }
             
             Seeq.Link.Agent.Program.Configuration config = Seeq.Link.Agent.Program.GetDefaultConfiguration();

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -21,7 +21,7 @@ namespace Seeq.Link.Debugging.Agent {
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             var seeqDataFolder = Path.Combine(Path.GetDirectoryName(executingAssemblyLocation), "data");
 
-            AgentKeyHelper.SetupAgentOtp(seeqDataFolder, agentName);
+            AgentOtpHelper.SetupAgentOtp(seeqDataFolder, agentName);
 
             Program.Configuration config = Program.GetDefaultConfiguration();
 

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -3,9 +3,6 @@ using System.IO;
 using System.Reflection;
 using log4net.Config;
 using Seeq.Link.Agent;
-using Seeq.Link.SDK.Services;
-using Seeq.Link.SDK.Utilities;
-using Seeq.Utilities;
 
 namespace Seeq.Link.Debugging.Agent {
 
@@ -24,20 +21,7 @@ namespace Seeq.Link.Debugging.Agent {
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             var seeqDataFolder = Path.Combine(Path.GetDirectoryName(executingAssemblyLocation), "data");
 
-            if (AgentKeyHelper.IsAgentOneTimePasswordSet()) {
-                var agentHelper = new AgentHelper(agentName);
-                var secretsPath = Path.Combine(seeqDataFolder, SeeqNames.Agents.AgentKeysFolderName, "agent.keys");
-                var secretsManager = new FileBasedSecretsManager(secretsPath);
-
-                // set the agent's pre-provisioned one-time password
-                var agentOneTimePassword = AgentKeyHelper.ReadAgentOneTimePassword();
-                var preProvisionedOneTimePasswordSecretName =
-                    $"{agentHelper.ProvisionedAgentUsername}|PRE_PROVISIONED_ONE_TIME_PASSWORD";
-                secretsManager.PutSecret(preProvisionedOneTimePasswordSecretName, agentOneTimePassword);
-
-                // clear the OTP
-                AgentKeyHelper.ResetAgentOneTimePasswordFile();
-            }
+            AgentKeyHelper.SetupAgentOtp(seeqDataFolder, agentName);
 
             Program.Configuration config = Program.GetDefaultConfiguration();
 

--- a/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/EntryPoint.cs
@@ -16,7 +16,6 @@ namespace Seeq.Link.Debugging.Agent {
     /// to connect to the server and load the connector that is under development.
     /// </summary>
     public class EntryPoint {
-        private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_one_time_password>";
 
         public static void Main(string[] args) {
             XmlConfigurator.Configure();
@@ -25,19 +24,19 @@ namespace Seeq.Link.Debugging.Agent {
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             var seeqDataFolder = Path.Combine(Path.GetDirectoryName(executingAssemblyLocation), "data");
 
-            // change this value to the one-time password generated from the Agents tab of your Seeq server's Administration
-            // page providing the machine name and your connector's name
-            const string agentOneTimePassword = AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
-
-            if (agentOneTimePassword != AGENT_ONE_TIME_PASSWORD_PLACEHOLDER) {
+            if (AgentKeyHelper.IsAgentOneTimePasswordSet()) {
                 var agentHelper = new AgentHelper(agentName);
                 var secretsPath = Path.Combine(seeqDataFolder, SeeqNames.Agents.AgentKeysFolderName, "agent.keys");
                 var secretsManager = new FileBasedSecretsManager(secretsPath);
 
                 // set the agent's pre-provisioned one-time password
+                var agentOneTimePassword = AgentKeyHelper.ReadAgentOneTimePassword();
                 var preProvisionedOneTimePasswordSecretName =
                     $"{agentHelper.ProvisionedAgentUsername}|PRE_PROVISIONED_ONE_TIME_PASSWORD";
                 secretsManager.PutSecret(preProvisionedOneTimePasswordSecretName, agentOneTimePassword);
+
+                // clear the OTP
+                AgentKeyHelper.ResetAgentOneTimePasswordFile();
             }
 
             Program.Configuration config = Program.GetDefaultConfiguration();

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -73,6 +73,7 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
     <PackageReference Include="Seeq.Link.Agent" Version="66.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -71,9 +71,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="data\keys\agent.key">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Seeq.Link.Agent" Version="66.0.0" />

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AgentKeyHelper.cs" />
     <Compile Include="EntryPoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -86,6 +87,11 @@
     <PackageReference Include="Seeq.Serialization">
       <Version>66.0.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="data\keys\agent.otp">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -66,7 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AgentKeyHelper.cs" />
+    <Compile Include="AgentOtpHelper.cs" />
     <Compile Include="EntryPoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.key
+++ b/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.key
@@ -1,2 +1,0 @@
-﻿agent_api_key
-<your_agent_api_key>

--- a/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.otp
+++ b/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.otp
@@ -1,0 +1,1 @@
+﻿<your_agent_one_time_password>


### PR DESCRIPTION
This PR switches the use of agent keys with a pre-provisioned OTP. I initially put backwards-compatibility logic in the Agent `EntryPoint` but since this is meant to be a base for **new** development then is no need for that and it was taken out. 

Reviewer: @mar1u50 (via CPR)

Exploratory testing notes:
- Pull the latest `crab`, `develop` branch, build and image.
- Start your local Seeq server, go to the Administration page and pre-provision an agent using your local _Machine Name_ as the machine name and _.NET Connector SDK Debugging Agent_ as the agent name.
- Open the  Seeq Connector SDK project in VS/Rider, change the following line, replacing `AGENT_ONE_TIME_PASSWORD_PLACEHOLDER` with the OTP from the step above
```csharp
const string agentOneTimePassword = AGENT_ONE_TIME_PASSWORD_PLACEHOLDER;
```
- Run the Agent project in Debug mode.
- Validate that the new Agent completes provisioning and the `My Connector: Type: My First Connection` datasource shows up and starts indexing
![image](https://github.com/user-attachments/assets/2088d8cb-aec6-472e-8f34-930828b1cda8)
- Validate that you can trend connector data.
- Kill the example Agent and restart debugging to verify that restarts do not affect the Agents ability to connect.