### PR TITLE
NO-CRAB: update `agent.otp` handling and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Take the following steps to confirm a properly configured development environmen
    on the Administration page. Click the "Add Agent" button and fill the presented fields. Provide the machine name and 
    "**.NET Connector SDK Debugging Agent**" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
    Copy the displayed one-time password.
-1. Replace `<your_agent_one_time_password>` in the `agent.otp` file located in the `/data/keys/` directory of the `Seeq.Link.SDK.Debugging.Agent` project with the one-time password copied in the previous step. **Note:** The `agent.otp` file will reset after the agent reads the entered value.
+1. Replace `<your_agent_one_time_password>` in the `agent.otp` file located in the `/data/keys/` directory of the 
+   `Seeq.Link.SDK.Debugging.Agent` project with the one-time password copied in the previous step. **Note:** The 
+   `agent.otp` file will reset after the agent reads the entered value.
 1. Set a breakpoint (*Debug* > *Toggle Breakpoint*) on the first line of the `Main()` function.
 1. Select *Debug* > *Start Debugging* to launch the debugger.
 1. You should hit the breakpoint you set. **This verifies that VS built your project correctly and can launch it in its
@@ -96,8 +98,7 @@ reading through the heavily-annotated source code. The template connector uses a
 the project and still build without errors.
 
 Any log messages you create using the `Log` property on `ConnectorServiceV2` and `DatasourceConnectionServiceV2` will go
-to the console window and to the `csharp/Seeq.Link.SDK.Debugging.Agent/bin/x64/Debug/log/net-debugging-agent.log` file 
-(replace `x64` with `x86` if you're on a 32-bit machine).
+to the console window and to the `csharp/Seeq.Link.SDK.Debugging.Agent/bin/x64/Debug/log/net-debugging-agent.log` file.
 
 ## Deploying your Connector
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ will use for development and debugging.
 
 Take the following steps to confirm a properly configured development environment:
 
-1. Once VS is finished loading, right click on the `Seeq.Link.SDK.Debugging.Agent` project in *Solution Explorer* and
+1. Once VS is finished loading, right-click on the `Seeq.Link.SDK.Debugging.Agent` project in *Solution Explorer* and
    select *Set as Startup Project*.
 1. In the solution configuration dropdown, select 'Debug'. **This step is required to ensure the necessary files are
    built for debugging.**
@@ -59,7 +59,8 @@ Take the following steps to confirm a properly configured development environmen
    on the Administration page. Click the "Add Agent" button and fill the presented fields. Provide the machine name and 
    ".NET Connector SDK Debugging Agent" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
    Copy the displayed one-time password.
-1. Replace `<your_agent_one_time_password>` in the `agent.otp` file in the /data/keys/ directory with the one-time password obtained from the previous step.
+1. Replace `<your_agent_one_time_password>` in the `agent.otp` file in the /data/keys/ directory of the 
+   `Seeq.Link.SDK.Debugging.Agent` project with the one-time password obtained from the previous step.
 1. Set a breakpoint (*Debug* > *Toggle Breakpoint*) on the first line of the `Main()` function.
 1. Select *Debug* > *Start Debugging* to launch the debugger.
 1. You should hit the breakpoint you set. **This verifies that VS built your project correctly and can launch it in its
@@ -85,18 +86,19 @@ possible to debug the connector.
 
 ## Developing your Connector
 
-We recommend that you just modify the template connector directly. This shields you from having to recreate all of the
+We recommend that you just modify the template connector directly. This shields you from having to recreate all the
 configuration that is required to correctly build and debug a new project. Visual Studio has excellent
 renaming/refactoring features that make it easy. For example, you can click on any item in VS's *Solution Explorer*
 and press *F2* to change it to something appropriate for your company and this particular connector.
 
 Once you are ready to start developing, just open the `MyConnector.cs` and `MyConnection.cs` files in VS and start
 reading through the heavily-annotated source code. The template connector uses a small class called
-`DatasourceSimulator`. You'll know you've removed all of the template-specific code when you can delete this file from
+`DatasourceSimulator`. You'll know you've removed all the template-specific code when you can delete this file from
 the project and still build without errors.
 
 Any log messages you create using the `Log` property on `ConnectorServiceV2` and `DatasourceConnectionServiceV2` will go
-to the console window and to the `csharp/Seeq.Link.SDK.Debugging.Agent/bin/Debug/log/net-debugging-agent.log` file.
+to the console window and to the `csharp/Seeq.Link.SDK.Debugging.Agent/bin/x64/Debug/log/net-debugging-agent.log` file 
+(replace `x64` with `x86` if you're on a 32-bit machine).
 
 ## Deploying your Connector
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Take the following steps to confirm a properly configured development environmen
 1. Modify the URL on the line `const string seeqHostUrl = "https://yourserver.seeq.host"` to match your Seeq server
 1. Pre-provision this agent on your Seeq server by logging in as a Seeq Administrator and navigating to the Agents tab 
    on the Administration page. Click the "Add Agent" button and fill the presented fields. Provide the machine name and 
-   ".NET Connector SDK Debugging Agent" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
+   "**.NET Connector SDK Debugging Agent**" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
    Copy the displayed one-time password.
 1. Replace `<your_agent_one_time_password>` in the `agent.otp` file in the /data/keys/ directory of the 
    `Seeq.Link.SDK.Debugging.Agent` project with the one-time password obtained from the previous step.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Take the following steps to confirm a properly configured development environmen
    on the Administration page. Click the "Add Agent" button and fill the presented fields. Provide the machine name and 
    "**.NET Connector SDK Debugging Agent**" as the agent name. Click "Add Agent". Wait for pre-provisioning to complete.
    Copy the displayed one-time password.
-1. Replace `<your_agent_one_time_password>` in the `agent.otp` file in the /data/keys/ directory of the 
-   `Seeq.Link.SDK.Debugging.Agent` project with the one-time password obtained from the previous step.
+1. Replace `<your_agent_one_time_password>` in the `agent.otp` file located in the `/data/keys/` directory of the `Seeq.Link.SDK.Debugging.Agent` project with the one-time password copied in the previous step. **Note:** The `agent.otp` file will reset after the agent reads the entered value.
 1. Set a breakpoint (*Debug* > *Toggle Breakpoint*) on the first line of the `Main()` function.
 1. Select *Debug* > *Start Debugging* to launch the debugger.
 1. You should hit the breakpoint you set. **This verifies that VS built your project correctly and can launch it in its

--- a/Seeq.Link.SDK.Debugging.Agent/AgentOtpHelper.cs
+++ b/Seeq.Link.SDK.Debugging.Agent/AgentOtpHelper.cs
@@ -7,7 +7,7 @@ namespace Seeq.Link.Debugging.Agent {
 
     internal static class AgentOtpHelper {
         private const string AGENT_ONE_TIME_PASSWORD_PLACEHOLDER = "<your_agent_one_time_password>";
-        private static string OtpFilePath = Path.Combine("data", "keys", "agent.otp");
+        private static string OtpFilePath = Path.Combine("..", "..", "..", "data", "keys", "agent.otp");
 
         public static void SetupAgentOtp(string seeqDataFolder, string agentName) {
             if (isAgentOneTimePasswordSet()) {

--- a/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
+++ b/Seeq.Link.SDK.Debugging.Agent/Seeq.Link.SDK.Debugging.Agent.csproj
@@ -89,9 +89,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="data\keys\agent.otp">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="data\keys\agent.otp" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.otp
+++ b/Seeq.Link.SDK.Debugging.Agent/data/keys/agent.otp
@@ -1,1 +1,1 @@
-﻿<your_agent_one_time_password>
+<your_agent_one_time_password>


### PR DESCRIPTION
This PR updates the README with improved instructions and changes the way the agent OTP file is read, opting to use the file in the project root instead of the one copied to the build directory.

NOT: when testing, ensure you run your Seeq server with the `--clean` flag and that you clear the build directory for the debugging agent to avoid [this bug](https://seeq.atlassian.net/browse/CRAB-46545).

**Reviewer**: @lcollins-seeq (volunteer)